### PR TITLE
Performance optimization

### DIFF
--- a/Mba.Simplifier/Bindings/AstCtx.cs
+++ b/Mba.Simplifier/Bindings/AstCtx.cs
@@ -199,6 +199,8 @@ namespace Mba.Simplifier.Bindings
             }
         }
 
+        // Apply term rewriting, but not recursively.
+        public unsafe AstIdx SingleSimplify(AstIdx id) => Api.ContextSingleSimplify(this, id);
         // Apply recursive term rewriting via ISLE.
         public unsafe AstIdx RecursiveSimplify(AstIdx id) => Api.ContextRecursiveSimplify(this, id);
 
@@ -294,6 +296,9 @@ namespace Mba.Simplifier.Bindings
 
             [DllImport("eq_sat")]
             public unsafe static extern ulong* ContextJit(OpaqueAstCtx* ctx, AstIdx id, ulong mask, uint isMultiBit, uint bitWidth, AstIdx* variableArray, ulong varCount, ulong numCombinations, ulong* rwxJitPage, ulong* outputArray);
+
+            [DllImport("eq_sat")]
+            public unsafe static extern AstIdx ContextSingleSimplify(OpaqueAstCtx* ctx, AstIdx id);
 
             [DllImport("eq_sat")]
             public unsafe static extern AstIdx ContextRecursiveSimplify(OpaqueAstCtx* ctx, AstIdx id);

--- a/Mba.Simplifier/Polynomial/Monomial.cs
+++ b/Mba.Simplifier/Polynomial/Monomial.cs
@@ -136,7 +136,7 @@ namespace Mba.Testing.PolyTesting
                     continue;
                 }
 
-                bool unroll = false;
+                bool unroll = true;
                 string pow = null;
                 if (canonicalBasis)
                     pow = GetCanonicalBasisStr(varName, degree, unroll);


### PR DESCRIPTION
- If an MBA is linear, only run the linear simplifier
- When recursively simplifying, expand multiplication by constant until a fixedpoint is reached
- Optimize runtime of polynomial reduction algorithm